### PR TITLE
Configure dependency bot for java21 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,6 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  target-branch: java17
-- package-ecosystem: docker
-  directory: "/"
-  schedule:
-    interval: daily
 - package-ecosystem: docker
   directory: "/"
   schedule:
@@ -23,3 +18,13 @@ updates:
   schedule:
     interval: daily
   target-branch: java11
+- package-ecosystem: docker
+  directory: "/"
+  schedule:
+    interval: daily
+  target-branch: java17
+- package-ecosystem: docker
+  directory: "/"
+  schedule:
+    interval: daily
+  target-branch: java21


### PR DESCRIPTION
1. Configured dependency bot scanning for target branch Java21 
2. Formatted in order 8,11,17,21 versions.